### PR TITLE
All layers extraction (Closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,13 @@ For each `.fif` file, the pipeline saves a `.npy` file with the same base name:
 - Input: `data/subject_001_raw.fif`
 - Output: `representations/labram/subject_001.npy`
 
-**Embedding shapes:**
-- **LaBraM**: `(200,)` - single vector per file
-- **CBraMod**: `(n_channels, n_patches, 200)` - preserves spatial-temporal structure
+**Embedding shapes (first dimension is ALWAYS layers for N×M comparisons):**
+- **LaBraM**: `(n_layers, 200)` = `(12, 200)` - embeddings from all 12 transformer blocks
+- **CBraMod**: `(n_layers, n_channels, n_patches, 200)` = `(12, n_ch, n_patches, 200)` - all 12 encoder layers
 - **Chronos**: `(n_channels, context_length, d_model)` - preserves channel and temporal structure
+
+**Why multi-layer extraction?**
+For Platonic Representation Hypothesis analysis, you build distance matrices per layer, then make N×M comparisons of k-nearest neighbours across two models (with N and M layers respectively).
 
 For RSA analysis, embeddings must have consistent shape **within** each model across files.
 
@@ -174,14 +177,14 @@ rdm = compute_rdm(labram_embs)
 
 ### LaBraM
 - **Input**: EEG at 200 Hz (channels padded/truncated to 128)
-- **Output**: `(200,)` - single vector per file
-- **Embedding source**: fc_norm layer (before classifier)
+- **Output**: `(12, 200)` - embeddings from all 12 transformer blocks
+- **Embedding source**: Forward hooks on each transformer block, mean pooled
 - **Reference**: [LaBraM Paper](https://github.com/935963004/LaBraM)
 
 ### CBraMod
 - **Input**: Multi-channel EEG at 200 Hz
-- **Output**: `(n_channels, n_patches, 200)` - preserves spatial-temporal structure
-- **Embedding source**: Encoder output (before proj_out)
+- **Output**: `(12, n_channels, n_patches, 200)` - all 12 encoder layers
+- **Embedding source**: Forward hooks on each TransformerEncoderLayer
 - **Reference**: [CBraMod](https://github.com/wjq-learning/CBraMod)
 
 ### Chronos

--- a/models/base.py
+++ b/models/base.py
@@ -64,11 +64,13 @@ class BaseExtractor(ABC):
             raw: MNE Raw object containing EEG data
             
         Returns:
-            numpy array of embeddings. Shape depends on model:
-            - (embedding_dim,) for single embedding per file
-            - (n_channels, embedding_dim) for per-channel embeddings
-            - (n_epochs, embedding_dim) for per-epoch embeddings
-            - (n_epochs, n_channels, embedding_dim) for per-epoch-per-channel
+            numpy array of embeddings. The FIRST DIMENSION is always the number
+            of layers (for multi-layer extraction to enable N×M comparisons).
+            
+            Typical shapes:
+            - (n_layers, embedding_dim) for LaBraM: (12, 200)
+            - (n_layers, n_channels, n_patches, embedding_dim) for CBraMod: (12, n_ch, n_patches, 200)
+            - (n_layers, n_channels, seq_len, d_model) for time series models
         """
         pass
     

--- a/models/cbramod_extractor.py
+++ b/models/cbramod_extractor.py
@@ -10,8 +10,12 @@ Architecture:
     → Output Projection (Linear) → (batch, ch, patches, 200)
 
 Embedding extraction:
-    We extract from the encoder output and mean pool across channels and patches
-    to get a 200-dimensional representation per file.
+    We extract embeddings from ALL 12 transformer encoder layers using forward hooks.
+    This enables N×M layer comparisons across models for the Platonic
+    Representation Hypothesis analysis.
+
+    Output shape: (n_layers, n_channels, n_patches, 200) = (12, n_ch, n_patches, 200)
+    First dimension is always the number of layers.
 
 Reference:
     - Paper: "CBraMod: A Criss-Cross Brain Foundation Model for EEG Decoding"
@@ -24,7 +28,7 @@ import mne
 import torch
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 from .base import BaseExtractor
 from .registry import register_extractor
 
@@ -38,15 +42,16 @@ class CBraModExtractor(BaseExtractor):
     - Input shape: (batch, ch_num, patch_num, patch_size=200)
     - patch_size=200 samples (1 second at 200 Hz)
     
-    Embedding is extracted from encoder output and mean pooled:
-    - encoder output: (batch, ch_num, patch_num, 200)
-    - mean pool → (batch, 200) → (200,) per file
+    Embeddings are extracted from ALL 12 transformer encoder layers using forward hooks.
+    Output shape: (n_layers, n_ch, n_patches, 200) = (12, n_ch, n_patches, 200)
+    First dimension is layers, enabling layer-wise comparisons.
     """
     
     MODEL_NAME = "cbramod"
     REQUIRED_SFREQ = 200.0  # CBraMod expects 200 Hz
     EMBEDDING_DIM = 200  # Output embedding dimension
     PATCH_SIZE = 200  # 1 second at 200 Hz
+    NUM_LAYERS = 12  # Number of transformer encoder layers
     
     def __init__(
         self,
@@ -55,7 +60,8 @@ class CBraModExtractor(BaseExtractor):
         verbose: bool = False,
     ):
         super().__init__(device=device, layer_name=layer_name, verbose=verbose)
-        self._encoder_output = None
+        self._layer_outputs: List[torch.Tensor] = []
+        self._hooks = []
     
     def load_model(self) -> None:
         """Load CBraMod pretrained model from HuggingFace using official code."""
@@ -124,27 +130,36 @@ class CBraModExtractor(BaseExtractor):
             self.model = self.model.to(self.device)
             self.model.eval()
             
-            # Register hook on encoder to capture output before proj_out
-            self._register_encoder_hook()
+            # Register hooks on all encoder layers to capture outputs
+            self._register_layer_hooks()
             
             self._is_loaded = True
             
             if self.verbose:
                 print(f"CBraMod loaded successfully!")
                 print(f"  - Embedding dimension: {self.EMBEDDING_DIM}")
+                print(f"  - Number of layers: {self.NUM_LAYERS}")
                 print(f"  - Patch size: {self.PATCH_SIZE} samples")
                 print(f"  - Expected sfreq: {self.REQUIRED_SFREQ} Hz")
             
         except Exception as e:
             raise RuntimeError(f"Failed to load CBraMod pretrained model: {e}")
     
-    def _register_encoder_hook(self):
-        """Register hook to capture encoder output before proj_out."""
-        def hook(module, input, output):
-            self._encoder_output = output.detach()
+    def _register_layer_hooks(self) -> None:
+        """Register forward hooks on all encoder layers to capture outputs."""
+        def make_hook(layer_idx: int):
+            def hook(module, input, output):
+                # output shape: (batch, ch_num, patch_num, d_model)
+                self._layer_outputs.append(output.detach())
+            return hook
         
-        # Hook on the encoder (the TransformerEncoder)
-        self.model.encoder.register_forward_hook(hook)
+        # CBraMod encoder has self.model.encoder.layers which is a ModuleList
+        for i, layer in enumerate(self.model.encoder.layers):
+            hook = layer.register_forward_hook(make_hook(i))
+            self._hooks.append(hook)
+        
+        if self.verbose:
+            print(f"  Registered hooks on {len(self._hooks)} encoder layers")
     
     def _prepare_input(self, raw: mne.io.Raw) -> torch.Tensor:
         """
@@ -186,11 +201,12 @@ class CBraModExtractor(BaseExtractor):
         """
         Extract embeddings from raw EEG data using CBraMod.
         
-        Uses encoder output (before proj_out), preserving full spatial-temporal structure.
+        Captures outputs from ALL 12 transformer encoder layers using forward hooks,
+        enabling N×M layer comparisons across models.
         
         Returns:
-            Embedding of shape (n_channels, n_patches, 200) - preserves structure
-            For RSA, this full tensor is compared across files.
+            Embedding of shape (n_layers, n_channels, n_patches, 200) = (12, n_ch, n_patches, 200)
+            First dimension is layers, enabling layer-wise comparisons.
         """
         # Prepare input
         x = self._prepare_input(raw)  # (1, n_channels, n_patches, 200)
@@ -198,19 +214,23 @@ class CBraModExtractor(BaseExtractor):
         if self.verbose:
             print(f"  Input shape: {x.shape}")
         
-        # Forward pass (hook captures encoder output)
+        # Clear previous layer outputs
+        self._layer_outputs = []
+        
+        # Forward pass (hooks capture all layer outputs)
         with torch.no_grad():
             _ = self.model(x)
         
-        # Get encoder output (before proj_out)
-        if self._encoder_output is not None:
-            feats = self._encoder_output  # (1, ch, patches, 200)
-        else:
-            # Fallback: use model output
-            feats = self.model(x)
+        # Stack all layer outputs
+        # Each layer output is (1, ch, patches, 200)
+        layer_embeddings = []
+        for layer_out in self._layer_outputs:
+            # Remove batch dimension: (ch, patches, 200)
+            layer_emb = layer_out.squeeze(0).cpu().numpy()
+            layer_embeddings.append(layer_emb)
         
-        # Remove batch dimension, keep full (n_channels, n_patches, 200) structure
-        embedding = feats.squeeze(0).cpu().numpy()  # (n_channels, n_patches, 200)
+        # Stack into (n_layers, n_ch, n_patches, 200)
+        embedding = np.stack(layer_embeddings, axis=0)
         
         if self.verbose:
             print(f"  Output embedding shape: {embedding.shape}")

--- a/models/labram_extractor.py
+++ b/models/labram_extractor.py
@@ -10,9 +10,12 @@ Architecture:
     → Classification Head
 
 Embedding extraction:
-    We use the `forward_features()` method which returns the 200-dimensional
-    representation AFTER mean pooling and fc_norm, BEFORE the classification head.
-    This is the standard approach for ViT-like models.
+    We extract embeddings from ALL 12 transformer blocks using forward hooks.
+    This enables N×M layer comparisons across models for the Platonic
+    Representation Hypothesis analysis.
+
+    Output shape: (n_layers, embedding_dim) = (12, 200)
+    First dimension is always the number of layers.
 
 Reference:
     - Paper: "Large Brain Model for Learning Generic Representations with Tremendous EEG Data in BCI"
@@ -23,7 +26,7 @@ Reference:
 import numpy as np
 import mne
 import torch
-from typing import Optional
+from typing import Optional, List
 from .base import BaseExtractor
 from .registry import register_extractor
 
@@ -38,12 +41,14 @@ class LaBraMExtractor(BaseExtractor):
     - 200 Hz sampling rate
     - Input shape: (batch, channels, time_samples)
     
-    Embedding is extracted from fc_norm layer (200-dim) using forward_features().
+    Embeddings are extracted from ALL 12 transformer blocks using forward hooks.
+    Output shape: (n_layers, 200) = (12, 200) where first dimension is layers.
     """
     
     MODEL_NAME = "labram"
     REQUIRED_SFREQ = 200.0  # LaBraM expects 200 Hz
     EMBEDDING_DIM = 200  # Output embedding dimension
+    NUM_LAYERS = 12  # Number of transformer blocks
     
     def __init__(
         self,
@@ -54,6 +59,8 @@ class LaBraMExtractor(BaseExtractor):
         super().__init__(device=device, layer_name=layer_name, verbose=verbose)
         self.n_chans_pretrained = 128  # Pretrained model has 128 channels
         self.n_times_pretrained = 3000  # 15 seconds at 200 Hz
+        self._layer_outputs: List[torch.Tensor] = []
+        self._hooks = []
     
     def load_model(self) -> None:
         """Load LaBraM pretrained model from HuggingFace via braindecode."""
@@ -68,11 +75,15 @@ class LaBraMExtractor(BaseExtractor):
             self.model = self.model.to(self.device)
             self.model.eval()
             
+            # Register hooks on all transformer blocks
+            self._register_layer_hooks()
+            
             self._is_loaded = True
             
             if self.verbose:
                 print(f"LaBraM loaded successfully!")
                 print(f"  - Embedding dimension: {self.EMBEDDING_DIM}")
+                print(f"  - Number of layers: {self.NUM_LAYERS}")
                 print(f"  - Expected channels: {self.n_chans_pretrained}")
                 print(f"  - Expected sfreq: {self.REQUIRED_SFREQ} Hz")
             
@@ -83,6 +94,22 @@ class LaBraMExtractor(BaseExtractor):
             )
         except Exception as e:
             raise RuntimeError(f"Failed to load LaBraM pretrained model: {e}")
+    
+    def _register_layer_hooks(self) -> None:
+        """Register forward hooks on all transformer blocks to capture layer outputs."""
+        def make_hook(layer_idx: int):
+            def hook(module, input, output):
+                # output shape: (batch, seq_len, embed_dim)
+                self._layer_outputs.append(output.detach())
+            return hook
+        
+        # LaBraM has self.model.blocks which is a ModuleList of transformer blocks
+        for i, block in enumerate(self.model.blocks):
+            hook = block.register_forward_hook(make_hook(i))
+            self._hooks.append(hook)
+        
+        if self.verbose:
+            print(f"  Registered hooks on {len(self._hooks)} transformer blocks")
     
     def _prepare_input(self, raw: mne.io.Raw) -> torch.Tensor:
         """
@@ -137,11 +164,12 @@ class LaBraMExtractor(BaseExtractor):
         """
         Extract embeddings from raw EEG data using LaBraM.
         
-        Uses the forward_features() method to get the 200-dim representation
-        from fc_norm (before the classification head).
+        Captures outputs from ALL 12 transformer blocks using forward hooks,
+        enabling N×M layer comparisons across models.
         
         Returns:
-            Embedding of shape (200,) - single vector per file
+            Embedding of shape (n_layers, 200) = (12, 200)
+            First dimension is layers, enabling layer-wise comparisons.
         """
         # Prepare input
         x = self._prepare_input(raw)  # (n_windows, 128, n_times)
@@ -149,22 +177,38 @@ class LaBraMExtractor(BaseExtractor):
         if self.verbose:
             print(f"  Input shape: {x.shape}")
         
-        # Extract embeddings using forward_features
-        embeddings_list = []
+        # Collect layer outputs across all windows
+        all_layer_embeddings = [[] for _ in range(self.NUM_LAYERS)]
         
         with torch.no_grad():
             for i in range(0, len(x), 8):  # Batch of 8
                 batch = x[i:i+8]
                 
-                # forward_features returns the embedding before classification head
-                emb = self.model.forward_features(batch)  # (batch, 200)
-                embeddings_list.append(emb.cpu().numpy())
+                # Clear previous layer outputs
+                self._layer_outputs = []
+                
+                # Forward pass triggers all hooks
+                _ = self.model.forward_features(batch)
+                
+                # Process layer outputs
+                # Each output is (batch, seq_len, embed_dim)
+                # We apply mean pooling to get (batch, embed_dim) per layer
+                for layer_idx, layer_out in enumerate(self._layer_outputs):
+                    # Mean pool across sequence dimension (same as forward_features does at the end)
+                    pooled = layer_out.mean(dim=1)  # (batch, embed_dim)
+                    all_layer_embeddings[layer_idx].append(pooled.cpu().numpy())
         
-        # Concatenate all window embeddings
-        embeddings = np.concatenate(embeddings_list, axis=0)  # (n_windows, 200)
+        # Concatenate windows and average for each layer
+        layer_embeddings = []
+        for layer_idx in range(self.NUM_LAYERS):
+            # Concatenate all batches: (total_windows, embed_dim)
+            layer_windows = np.concatenate(all_layer_embeddings[layer_idx], axis=0)
+            # Average across windows: (embed_dim,)
+            layer_avg = layer_windows.mean(axis=0)
+            layer_embeddings.append(layer_avg)
         
-        # Average across windows to get single representation per file
-        embedding = embeddings.mean(axis=0)  # (200,)
+        # Stack into (n_layers, embed_dim)
+        embedding = np.stack(layer_embeddings, axis=0)  # (12, 200)
         
         if self.verbose:
             print(f"  Output embedding shape: {embedding.shape}")


### PR DESCRIPTION
This PR addresses the issue of extracting only the final layer representation from EEG foundation models. To enable N×M layer comparisons across different models (as required for Platonic Representation Hypothesis analysis), I have updated the extraction pipeline to capture embeddings from all transformer layers.

## Related issue
Closes #1 